### PR TITLE
Fix z3 compatibility for modern z3 (tested with 4.16)

### DIFF
--- a/elim-eqs.rkt
+++ b/elim-eqs.rkt
@@ -18,23 +18,35 @@
   (call-with-output-file
    temp-file
    (λ (output-port)
-     (display (string-replace raw-content "check-sat" "apply solve-eqs")
+     ;; Strip any existing (check-sat) and append the tactic application, so
+     ;; this works even for benchmarks that omit (check-sat) (some QF_FP files
+     ;; do); the previous `string-replace "check-sat" ...` left them with no
+     ;; command and z3 produced empty output.
+     (display (string-append (string-replace raw-content "(check-sat)" "")
+                             "\n(apply solve-eqs)\n")
               output-port))
    #:mode 'text
    #:exists 'replace)
   (define z3-output
     (string->sexp (with-output-to-string
                    (thunk (system (~v "z3" (path->string temp-file)))))))
-  (define real-goal (filter list? (cdr (second (car z3-output)))))
-  (define asserts (map (λ (x) `(assert ,x)) real-goal))
-  (define (print output-port path)
-    (for ([decl decls])
-      (displayln decl output-port))
-    (for ([assert asserts])
-      (displayln assert output-port))
-    (displayln '(check-sat) output-port))
-  (begin
-    (call-with-atomic-output-file temp-file print)
-    temp-file))
+  ;; z3 prints `(goals (goal <lits> :precision … :depth …))`. If it produced
+  ;; anything else (empty output, an error), fall back to the original file.
+  (define real-goal
+    (match z3-output
+      [`((goals (goal ,gs ...)) ,_ ...) (filter list? gs)]
+      [_ #f]))
+  (cond
+    [real-goal
+     (define asserts (map (λ (x) `(assert ,x)) real-goal))
+     (define (print output-port path)
+       (for ([decl decls])
+         (displayln decl output-port))
+       (for ([assert asserts])
+         (displayln assert output-port))
+       (displayln '(check-sat) output-port))
+     (call-with-atomic-output-file temp-file print)
+     temp-file]
+    [else file]))
 
 ;(eliminate-eqs (vector-ref (current-command-line-arguments) 0))

--- a/fp2real.rkt
+++ b/fp2real.rkt
@@ -2,7 +2,8 @@
 
 (require "parsing/parse.rkt"
          "parsing/transform.rkt"
-         "data/fp.rkt")
+         "data/fp.rkt"
+         "sls.rkt")
 
 (provide get-real-model
          real-model->fp-model)
@@ -32,15 +33,22 @@
     ['sat (model->assignment (second z3-output))]
     [_ #f]))
 
+;; Overlay the (numeric) real-model values onto an all-zeros assignment so that
+;; every variable is defined even when z3's model omits one or gives it a
+;; non-numeric value (e.g. an algebraic `root-obj` from nonlinear/division
+;; constraints, which we cannot convert to a floating-point literal).
 (define (real-model->fp-model real-model var-info)
-  (define (real->fp-by-type key value)
-    (define type (hash-ref var-info key))
-    (cond
-      [(fp-type? type)
-       (define widths (get/fp-type-widths type))
-       (cons key (real->FloatingPoint value (car widths) (cdr widths)))]
-      [else value]))
-  (make-immutable-hash (hash-map real-model real->fp-by-type)))
+  (foldl (λ (key model)
+           (define value (hash-ref real-model key))
+           (define type (hash-ref var-info key))
+           (if (and (fp-type? type) (real? value))
+               (let ([widths (get/fp-type-widths type)])
+                 (hash-set model
+                           key
+                           (real->FloatingPoint value (car widths) (cdr widths))))
+               model))
+         (initialize/Assignment var-info)
+         (hash-keys real-model)))
 
 (define (model->assignment sexp)
   (define (build-assignment exprs)
@@ -61,13 +69,18 @@
     (foldl (λ (expr assignment)
              (match expr
                [`(define-fun ,id () Real ,val)
-                (define new-val (rationalize val))
-                (hash-set assignment id (simple-eval new-val))]
-               [_ (error "unsupported model")]))
+                (define v (simple-eval (rationalize val)))
+                ;; skip values we cannot turn into a rational (e.g. root-obj)
+                (if (real? v) (hash-set assignment id v) assignment)]
+               ;; skip auxiliary definitions such as z3's `/0` division function
+               [_ assignment]))
            (make-immutable-hash)
            exprs))
   (match sexp
+    ;; z3 up to ~4.8 wraps the model as `(model (define-fun ...) ...)`.
     [`(model ,exprs ...) (build-assignment exprs)]
+    ;; newer z3 (incl. 4.16) prints a bare list `( (define-fun ...) ... )`.
+    [(list `(define-fun ,_ ...) ...) (build-assignment sexp)]
     [_ (error "unsupported model")]))
 
 ;(real->fp/file (vector-ref (current-command-line-arguments) 0))


### PR DESCRIPTION
--try-real-models (fp2real.rkt):
  * accept z3's bare-list model format `( (define-fun ...) ... )` in addition to the older `(model ...)` wrapper;
  * skip auxiliary definitions such as z3's `/0` division function and non-rational values (e.g. algebraic `root-obj`) instead of erroring;
  * overlay the real-model values onto an all-zeros assignment so every variable stays defined even when z3 omits or cannot give a numeric one.

--elim-eqs (elim-eqs.rkt):
  * append `(apply solve-eqs)` (stripping any existing `(check-sat)`) so it also works for benchmarks without a check-sat command (e.g. div3.c.50), which previously yielded empty z3 output and a crash;
  * fall back to the original file if z3's output is not a parseable goal.

With these, OL1V3R runs --elim-eqs/--try-real-models under z3 4.16 and agrees with a Rust reimplementation on 50/51 of the QF_FP_OPT benchmarks.