### PR TITLE
Add default z3 simplification preprocessing (jfs-opt equivalent)

### DIFF
--- a/elim-eqs.rkt
+++ b/elim-eqs.rkt
@@ -34,11 +34,15 @@
   (call-with-output-file
    temp-file
    (λ (output-port)
-     ;; Strip any existing (check-sat) and append the tactic application, so
-     ;; this works even for benchmarks that omit (check-sat).
-     (display (string-append (string-replace raw-content "(check-sat)" "")
-                             "\n(apply " tactic ")\n")
-              output-port))
+     ;; Strip the trailing solver commands and append the tactic application.
+     ;; (exit) must be removed too, not just (check-sat): many SMT-LIB files end
+     ;; with `(check-sat) (exit)`, and a leftover (exit) makes z3 quit before
+     ;; reaching the appended tactic (empty output -> silent fallback).
+     (define stripped
+       (foldl (λ (s acc) (string-replace acc s ""))
+              raw-content
+              '("(check-sat)" "(exit)" "(get-model)" "(get-unsat-core)")))
+     (display (string-append stripped "\n(apply " tactic ")\n") output-port))
    #:mode 'text
    #:exists 'replace)
   (define z3-output

--- a/elim-eqs.rkt
+++ b/elim-eqs.rkt
@@ -1,40 +1,56 @@
 #lang racket
 
 (require "parsing/parse.rkt")
-(provide eliminate-eqs)
+(provide eliminate-eqs simplify-jfs)
 
-;; use Z3's solve-eqs tactic to remove equalities
-(define (eliminate-eqs file)
+;; The `jfs-opt --standard-passes` pipeline, reproduced with z3 tactics alone.
+;; JFS's SimplificationPass is z3's `simplify` (with `bv_ite2id=true`) and its
+;; ConstantPropagationPass is z3's `propagate-values`; the other standard passes
+;; (and-hoist, true/duplicate-constraint elimination, contradiction->false) are
+;; done for free by z3's goal/(apply ...) machinery. So this single tactic
+;; reproduces the pipeline with no JFS (LLVM/clang) build. `propagate-values`,
+;; not `solve-eqs`, so no declared variable is substituted away.
+(define jfs-opt-tactic
+  (string-append "(then (! simplify :bv_ite2id true) "
+                 "propagate-values "
+                 "(! simplify :bv_ite2id true) "
+                 "propagate-values "
+                 "(! simplify :bv_ite2id true))"))
+
+;; Apply a z3 tactic to `file` and return the path to a rewritten SMT-LIB file
+;; (original declarations + the resulting goal's literals + check-sat). Robust
+;; to inputs without (check-sat) and to z3 emitting an unexpected result: in
+;; those cases it falls back to the original file rather than dropping asserts.
+(define (apply-tactic file tactic)
   (define temp-file (make-temporary-file "rkttmp~a" file))
   (define raw-content (file->string file #:mode 'text))
-  (define raw-expr (string->sexp raw-content))
   (define decls
     (filter (λ (e)
               (match e
                 [`(declare-const ,id ,type) #t]
                 [`(declare-fun ,id () ,type) #t]
                 [_ #f]))
-            raw-expr))
+            (string->sexp raw-content)))
   (call-with-output-file
    temp-file
    (λ (output-port)
      ;; Strip any existing (check-sat) and append the tactic application, so
-     ;; this works even for benchmarks that omit (check-sat) (some QF_FP files
-     ;; do); the previous `string-replace "check-sat" ...` left them with no
-     ;; command and z3 produced empty output.
+     ;; this works even for benchmarks that omit (check-sat).
      (display (string-append (string-replace raw-content "(check-sat)" "")
-                             "\n(apply solve-eqs)\n")
+                             "\n(apply " tactic ")\n")
               output-port))
    #:mode 'text
    #:exists 'replace)
   (define z3-output
     (string->sexp (with-output-to-string
                    (thunk (system (~v "z3" (path->string temp-file)))))))
-  ;; z3 prints `(goals (goal <lits> :precision … :depth …))`. If it produced
-  ;; anything else (empty output, an error), fall back to the original file.
+  ;; z3 prints `(goals (goal <lits> :precision … :depth …))`. Take the literals
+  ;; up to the first `:keyword` (so a bare `false`/`true` goal is preserved);
+  ;; fall back to the original file if the output is not a parseable goal.
+  (define (keyword? x) (and (symbol? x) (string-prefix? (symbol->string x) ":")))
   (define real-goal
     (match z3-output
-      [`((goals (goal ,gs ...)) ,_ ...) (filter list? gs)]
+      [`((goals (goal ,gs ...)) ,_ ...) (takef gs (λ (x) (not (keyword? x))))]
       [_ #f]))
   (cond
     [real-goal
@@ -49,4 +65,8 @@
      temp-file]
     [else file]))
 
-;(eliminate-eqs (vector-ref (current-command-line-arguments) 0))
+;; use Z3's solve-eqs tactic to remove equalities
+(define (eliminate-eqs file) (apply-tactic file "solve-eqs"))
+
+;; jfs-opt-equivalent simplification (z3 only)
+(define (simplify-jfs file) (apply-tactic file jfs-opt-tactic))

--- a/main.rkt
+++ b/main.rkt
@@ -19,6 +19,7 @@
            [try-real-models? (make-parameter #f)]
            [print-models? (make-parameter #f)]
            [elim-eqs? (make-parameter #f)]
+           [simplify? (make-parameter #t)]
            [vns (make-parameter #f)]
            [enable-log (make-parameter #f)]
            [file-to-analyze
@@ -64,13 +65,18 @@
               (try-real-models? #t)]
              ["--vns" ("Enable variable neighborhood search") (vns #t)]
              ["--elim-eqs" ("Enable Z3 `solve-eqs` tactics") (elim-eqs? #t)]
+             ["--no-simplify"
+              ("Disable z3 simplification preprocessing (jfs-opt equivalent)")
+              (simplify? #f)]
              ["--print-models" ("Print models") (print-models? #t)]
              ["--debug" ("Enable logger") (enable-log #t)]
              #:args (filename) ; expect one command-line argument: <filename>
              ; return the argument as a filename to compile
              filename)]
+           [simplified-file
+            (if (simplify?) (simplify-jfs file-to-analyze) file-to-analyze)]
            [input-file
-            (if (elim-eqs?) (eliminate-eqs file-to-analyze) file-to-analyze)]
+            (if (elim-eqs?) (eliminate-eqs simplified-file) simplified-file)]
            [script (file->sexp input-file)]
            [formula (remove-fpconst
                      (simplify (unnest (formula->nnf (remove-let-bindings


### PR DESCRIPTION
jfs-opt's standard pipeline is just z3 `simplify` (with bv_ite2id) + `propagate-values`; the other passes are done for free by z3's (apply ...) goal machinery. So reproduce it with one z3 tactic and drop the JFS (LLVM/ clang) build dependency for benchmark preprocessing.

- Generalize elim-eqs.rkt into apply-tactic; add simplify-jfs.
- main.rkt: simplify on by default (--no-simplify to skip), applied before --elim-eqs. Folds away constructs OL1V3R can't evaluate (e.g. constant ite) and preserves declared variables (propagate-values, not solve-eqs).