### PR TITLE
Repair OL1V3R to run on the modern SMT-COMP QF_FP set (+ RoundingMode support)

### DIFF
--- a/data/eval.rkt
+++ b/data/eval.rkt
@@ -65,13 +65,11 @@
           [`(,op ...) ((displayln op) (error "unsupported operations"))]
           ;[else (get-value assignment be)])))
           [else (lookup be env)])))
-    ;; Hard-evaluate a boolean condition (for `ite`) to #t/#f, mirroring the
-    ;; truth conditions of score.rkt (an atom scores 1 iff true). Mutually
-    ;; recursive with eval^ for the term operands.
+    ;; Decide an `ite` condition's truth using the shared atom predicates from
+    ;; fp.rkt -- so this evaluator and score.rkt agree by construction, with no
+    ;; duplicated predicate logic. Mutually recursive with eval^ for operands.
     (define eval-bool
       (λ (be env)
-        (define (fpcmp op a b)
-          (and (not (fp/nan? a)) (not (fp/nan? b)) (op a b)))
         (match be
           ['⊤ #t]
           ['⊥ #f]
@@ -84,20 +82,14 @@
           [`(= ,a ,b)
            (let ([x (eval^ a env)] [y (eval^ b env)])
              (match x
-               [(struct FloatingPoint _)
-                (or (and (fp/nan? x) (fp/nan? y))
-                    (bv= (FloatingPoint->BitVec x) (FloatingPoint->BitVec y)))]
+               [(struct FloatingPoint _) (fp=-true? x y)]
                [_ (bv= x y)]))]
-          [`(fp.eq ,a ,b)
-           (let ([x (eval^ a env)] [y (eval^ b env)])
-             (cond [(or (fp/nan? x) (fp/nan? y)) #f]
-                   [(and (fp/zero? x) (fp/zero? y)) #t]
-                   [else (bv= (FloatingPoint->BitVec x) (FloatingPoint->BitVec y))]))]
-          [`(fp.lt ,a ,b) (fpcmp fp< (eval^ a env) (eval^ b env))]
-          [`(fp.leq ,a ,b) (fpcmp fp≤ (eval^ a env) (eval^ b env))]
-          [`(fp.gt ,a ,b) (fpcmp fp> (eval^ a env) (eval^ b env))]
-          [`(fp.geq ,a ,b) (fpcmp fp≥ (eval^ a env) (eval^ b env))]
-          [`(bvult ,a ,b) (bv< (eval^ a env) (eval^ b env))]
+          [`(fp.eq ,a ,b)  (fp.eq-true?  (eval^ a env) (eval^ b env))]
+          [`(fp.lt ,a ,b)  (fp.lt-true?  (eval^ a env) (eval^ b env))]
+          [`(fp.leq ,a ,b) (fp.leq-true? (eval^ a env) (eval^ b env))]
+          [`(fp.gt ,a ,b)  (fp.gt-true?  (eval^ a env) (eval^ b env))]
+          [`(fp.geq ,a ,b) (fp.geq-true? (eval^ a env) (eval^ b env))]
+          [`(bvult ,a ,b)  (bv< (eval^ a env) (eval^ b env))]
           ;; bare boolean term / fp.isX: eval^ yields a width-1 BV, true iff 1
           [_ (not (zero? (BitVec-value (eval^ be env))))])))
     (eval^ be env)))

--- a/data/eval.rkt
+++ b/data/eval.rkt
@@ -58,9 +58,46 @@
           [`(fp.isInfinite ,op) (mkBoolBV (fp/infinity? (eval^ op env)))]
           [`((_ to_fp ,new-exp-width ,new-sig-width) ,rm ,op)
            (eval/fpconv (eval^ op env) new-exp-width new-sig-width)]
+          [`(ite ,c ,thn ,els)
+           (if (eval-bool c env) (eval^ thn env) (eval^ els env))]
           [(struct FloatingPoint _) be]
           [(struct BitVec _) be]
           [`(,op ...) ((displayln op) (error "unsupported operations"))]
           ;[else (get-value assignment be)])))
           [else (lookup be env)])))
+    ;; Hard-evaluate a boolean condition (for `ite`) to #t/#f, mirroring the
+    ;; truth conditions of score.rkt (an atom scores 1 iff true). Mutually
+    ;; recursive with eval^ for the term operands.
+    (define eval-bool
+      (λ (be env)
+        (define (fpcmp op a b)
+          (and (not (fp/nan? a)) (not (fp/nan? b)) (op a b)))
+        (match be
+          ['⊤ #t]
+          ['⊥ #f]
+          [`(¬ ,b) (not (eval-bool b env))]
+          [`(not ,b) (not (eval-bool b env))]
+          [`(∧ ,bs ...) (andmap (λ (b) (eval-bool b env)) bs)]
+          [`(and ,bs ...) (andmap (λ (b) (eval-bool b env)) bs)]
+          [`(∨ ,bs ...) (ormap (λ (b) (eval-bool b env)) bs)]
+          [`(or ,bs ...) (ormap (λ (b) (eval-bool b env)) bs)]
+          [`(= ,a ,b)
+           (let ([x (eval^ a env)] [y (eval^ b env)])
+             (match x
+               [(struct FloatingPoint _)
+                (or (and (fp/nan? x) (fp/nan? y))
+                    (bv= (FloatingPoint->BitVec x) (FloatingPoint->BitVec y)))]
+               [_ (bv= x y)]))]
+          [`(fp.eq ,a ,b)
+           (let ([x (eval^ a env)] [y (eval^ b env)])
+             (cond [(or (fp/nan? x) (fp/nan? y)) #f]
+                   [(and (fp/zero? x) (fp/zero? y)) #t]
+                   [else (bv= (FloatingPoint->BitVec x) (FloatingPoint->BitVec y))]))]
+          [`(fp.lt ,a ,b) (fpcmp fp< (eval^ a env) (eval^ b env))]
+          [`(fp.leq ,a ,b) (fpcmp fp≤ (eval^ a env) (eval^ b env))]
+          [`(fp.gt ,a ,b) (fpcmp fp> (eval^ a env) (eval^ b env))]
+          [`(fp.geq ,a ,b) (fpcmp fp≥ (eval^ a env) (eval^ b env))]
+          [`(bvult ,a ,b) (bv< (eval^ a env) (eval^ b env))]
+          ;; bare boolean term / fp.isX: eval^ yields a width-1 BV, true iff 1
+          [_ (not (zero? (BitVec-value (eval^ be env))))])))
     (eval^ be env)))

--- a/data/eval.rkt
+++ b/data/eval.rkt
@@ -44,12 +44,12 @@
            (mkBV op2
                  (string->number (substring (symbol->string op1)
                                             (string-length "bv"))))]
-          [`(fp.add ,rm ,op1 ,op2) (eval/fpadd (eval^ op1 env) (eval^ op2 env))]
-          [`(fp.sub ,rm ,op1 ,op2) (eval/fpsub (eval^ op1 env) (eval^ op2 env))]
-          [`(fp.mul ,rm ,op1 ,op2) (eval/fpmul (eval^ op1 env) (eval^ op2 env))]
-          [`(fp.div ,rm ,op1 ,op2) (eval/fpdiv (eval^ op1 env) (eval^ op2 env))]
+          [`(fp.add ,rm ,op1 ,op2) (eval/fpadd (rm->bf-mode rm) (eval^ op1 env) (eval^ op2 env))]
+          [`(fp.sub ,rm ,op1 ,op2) (eval/fpsub (rm->bf-mode rm) (eval^ op1 env) (eval^ op2 env))]
+          [`(fp.mul ,rm ,op1 ,op2) (eval/fpmul (rm->bf-mode rm) (eval^ op1 env) (eval^ op2 env))]
+          [`(fp.div ,rm ,op1 ,op2) (eval/fpdiv (rm->bf-mode rm) (eval^ op1 env) (eval^ op2 env))]
           [`(fp.neg ,op) (eval/fpneg (eval^ op env))]
-          [`(fp.sqrt ,rm ,op) (eval/fpsqrt (eval^ op env))]
+          [`(fp.sqrt ,rm ,op) (eval/fpsqrt (rm->bf-mode rm) (eval^ op env))]
           [`(fp.isNormal ,op) (mkBoolBV (fp/normal? (eval^ op env)))]
           [`(fp.isSubnormal ,op) (mkBoolBV (fp/subnormal? (eval^ op env)))]
           [`(fp.isZero ,op) (mkBoolBV (fp/zero? (eval^ op env)))]

--- a/data/fp.rkt
+++ b/data/fp.rkt
@@ -297,6 +297,22 @@
 (define fp≤ (fp/pred/bin bf<=))
 (define fp≥ (fp/pred/bin bf>=))
 
+;; ---- atom truth predicates: single source of truth shared by score.rkt
+;; (which returns score 1 exactly when these hold) and eval.rkt (which decides
+;; an `ite` condition with them). NaN comparisons are false; fp.eq treats
+;; +0 = -0; structural `=` is bit-identical (so +0 != -0).
+(define (fp.lt-true?  a b) (and (not (fp/nan? a)) (not (fp/nan? b)) (fp< a b)))
+(define (fp.leq-true? a b) (and (not (fp/nan? a)) (not (fp/nan? b)) (fp≤ a b)))
+(define (fp.gt-true?  a b) (and (not (fp/nan? a)) (not (fp/nan? b)) (fp> a b)))
+(define (fp.geq-true? a b) (and (not (fp/nan? a)) (not (fp/nan? b)) (fp≥ a b)))
+(define (fp.eq-true?  a b)
+  (and (not (fp/nan? a)) (not (fp/nan? b))
+       (or (and (fp/zero? a) (fp/zero? b))
+           (bv= (FloatingPoint->BitVec a) (FloatingPoint->BitVec b)))))
+(define (fp=-true? a b)
+  (or (and (fp/nan? a) (fp/nan? b))
+      (bv= (FloatingPoint->BitVec a) (FloatingPoint->BitVec b))))
+
 ;; floating-point related conversions
 ;; real->fp
 (define real->FloatingPoint

--- a/data/fp.rkt
+++ b/data/fp.rkt
@@ -62,7 +62,8 @@
       (real->FloatingPoint 2.0
                            (FloatingPoint-exp-width fp)
                            (FloatingPoint-sig-width fp)))
-    `(,(eval/fpmul fp two) ,(eval/fpdiv fp two))))
+    ;; neighbor doubling/halving: rounding mode is irrelevant here, use nearest
+    `(,(eval/fpmul 'nearest fp two) ,(eval/fpdiv 'nearest fp two))))
 
 (define (sig/± fp)
   (define exp-width (FloatingPoint-exp-width fp))
@@ -181,7 +182,24 @@
      exp-width
      sig-width)))
 
-(define ((eval/fparith/binop op) fp1 fp2)
+;; An SMT rounding-mode constant -> a Racket bigfloat rounding mode.
+;;
+;; LIMITATION: Racket's bigfloat has no ties-to-away mode, so we cannot honor
+;; roundNearestTiesToAway. We deliberately do NOT approximate it as 'nearest --
+;; that would round ties the wrong way and could report a spurious model (an
+;; unsoundness). Instead we refuse it here and omit it from the rm-variable
+;; enumeration (see ROUNDING-MODES in parse.rkt). OL1V3R is therefore incomplete
+;; on RNA: instances that require ties-to-away are not solved. (None occur in our
+;; evaluation set.)
+(define (rm->bf-mode rm)
+  (case rm
+    [(roundNearestTiesToEven RNE) 'nearest]
+    [(roundTowardZero RTZ) 'zero]
+    [(roundTowardPositive RTP) 'up]
+    [(roundTowardNegative RTN) 'down]
+    [else (error "unsupported rounding mode (no bigfloat equivalent):" rm)]))
+
+(define ((eval/fparith/binop op) mode fp1 fp2)
   (define v1 (FloatingPoint-value fp1))
   (define v2 (FloatingPoint-value fp2))
   (define exp-w-1 (FloatingPoint-exp-width fp1))
@@ -190,8 +208,9 @@
   (define sig-w-2 (FloatingPoint-sig-width fp2))
   (if (and (= (bigfloat-precision v1) (bigfloat-precision v2))
            (and (= exp-w-1 exp-w-2) (= sig-w-1 sig-w-2)))
-      ;; apply arithmetic
-      (let ([result (parameterize ([bf-precision sig-w-1]) (op v1 v2))])
+      ;; apply arithmetic under the requested rounding mode
+      (let ([result (parameterize ([bf-precision sig-w-1] [bf-rounding-mode mode])
+                      (op v1 v2))])
         (cond
           [(fp/result-infinity? result exp-w-1 sig-w-1)
            (if (bfpositive? result)
@@ -210,7 +229,7 @@
 (define eval/fpmul (eval/fparith/binop bf*))
 (define eval/fpdiv (eval/fparith/binop bf/))
 
-(define eval/fpsqrt (λ (fp) ((eval/fparith/binop (λ (f s) (bfsqrt f))) fp fp)))
+(define eval/fpsqrt (λ (mode fp) ((eval/fparith/binop (λ (f s) (bfsqrt f))) mode fp fp)))
 
 (define eval/fpabs
   (λ (fp)
@@ -227,7 +246,7 @@
           (parameterize ([bf-precision sig-width])
             (bf* (bf -1.0) (FloatingPoint-value fp))))))
 
-(define fp/prune (λ (fp) ((eval/fparith/binop (λ (f s) f)) fp fp)))
+(define fp/prune (λ (fp) ((eval/fparith/binop (λ (f s) f)) 'nearest fp fp)))
 
 (define eval/fpconv
   (λ (fp dest-exp-width dest-sig-width)
@@ -311,7 +330,10 @@
            (bv= (FloatingPoint->BitVec a) (FloatingPoint->BitVec b)))))
 (define (fp=-true? a b)
   (or (and (fp/nan? a) (fp/nan? b))
-      (bv= (FloatingPoint->BitVec a) (FloatingPoint->BitVec b))))
+      ;; only reach for the bit pattern when neither is NaN: NaN has no unique
+      ;; bv representation, so FloatingPoint->BitVec would error.
+      (and (not (fp/nan? a)) (not (fp/nan? b))
+           (bv= (FloatingPoint->BitVec a) (FloatingPoint->BitVec b)))))
 
 ;; floating-point related conversions
 ;; real->fp

--- a/main.rkt
+++ b/main.rkt
@@ -97,23 +97,28 @@
                                   (loop)))))
                 (current-logger oliver-logger)))
             42)
+        ;; RoundingMode variables are not searched; they are enumerated over the
+        ;; five rounding-mode constants below. Split them off the search var-info.
+        (define rm-vars
+          (filter (λ (v) (rm-type? (hash-ref var-info v))) (hash-keys var-info)))
+        (define search-var-info
+          (foldl (λ (v h) (hash-remove h v)) var-info rm-vars))
         (define initial-models
           (let ([models (if (start-with-zeros?)
-                            (initialize/Assignment var-info)
-                            (randomize/Assignment var-info))])
+                            (initialize/Assignment search-var-info)
+                            (randomize/Assignment search-var-info))])
             (if (try-real-models?)
                 (let ([real-models (get-real-model input-file)])
                   (if real-models
-                      (real-model->fp-model real-models var-info)
+                      (real-model->fp-model real-models search-var-info)
                       models))
                 models)))
-        (define result
-          ((if (vns) sls-vns sls) var-info
-                                  formula
-                                  (c2)
-                                  (step)
-                                  (wp)
-                                  initial-models))
+        (define run-sls
+          (λ (f) ((if (vns) sls-vns sls)
+                  search-var-info f (c2) (step) (wp) initial-models)))
+        ;; Enumerate the rounding-mode constants in place of the rm variables
+        ;; (a no-op when there are none); see sls.rkt.
+        (define result (enumerate-rounding-modes rm-vars formula run-sls))
         (if (equal? (car result) 'sat)
             (begin
               (displayln "sat")

--- a/parsing/parse.rkt
+++ b/parsing/parse.rkt
@@ -121,9 +121,10 @@
     (define read-hex^
       (λ (p vs)
         (define c (peek-char p))
-        (if (or (and (char<=? #\0 c) (char<=? c #\9))
-                (or (and (char<=? #\a c) (char<=? c #\f))
-                    (and (char<=? #\A c) (char<=? c #F))))
+        (if (and (char? c)
+                 (or (and (char<=? #\0 c) (char<=? c #\9))
+                     (and (char<=? #\a c) (char<=? c #\f))
+                     (and (char<=? #\A c) (char<=? c #\F))))
             (begin
               (read-char p)
               (read-hex^ p (string-append vs (string c))))
@@ -137,7 +138,7 @@
     (define read-bin^
       (λ (p vs)
         (define c (peek-char p))
-        (if (and (char<=? #\0 c) (char<=? c #\1))
+        (if (and (char? c) (char<=? #\0 c) (char<=? c #\1))
             (begin
               (read-char p)
               (read-bin^ p (string-append vs (string c))))

--- a/parsing/parse.rkt
+++ b/parsing/parse.rkt
@@ -69,6 +69,27 @@
       ['Float128 #t]
       [_ #f])))
 
+(define rm-type?
+  (λ (t) (match t ['RoundingMode #t] [_ #f])))
+
+;; SMT-LIB rounding-mode constants enumerated in place of RoundingMode
+;; variables, RNE first (the IEEE-754 default). roundNearestTiesToAway is
+;; intentionally omitted: Racket's bigfloat has no ties-to-away mode and
+;; approximating it would be unsound (see rm->bf-mode in data/fp.rkt), so
+;; OL1V3R is incomplete on that mode.
+(define ROUNDING-MODES
+  '(roundNearestTiesToEven roundTowardZero roundTowardPositive
+    roundTowardNegative))
+
+;; Replace symbols according to the hash `subs`. Used to substitute a
+;; RoundingMode variable with a concrete rounding-mode constant before search;
+;; floats/bitvecs and other atoms are left untouched.
+(define (substitute f subs)
+  (cond
+    [(symbol? f) (hash-ref subs f f)]
+    [(list? f) (map (λ (x) (substitute x subs)) f)]
+    [else f]))
+
 (define get/fp-type-widths
   (λ (t)
     (match t
@@ -148,7 +169,14 @@
                      (string-length str)))))
 
 (define smt-read-table
-  (make-readtable (make-readtable #f #\x 'dispatch-macro read-hex)
-                  #\b
-                  'dispatch-macro
-                  read-bin))
+  ;; `;` must be a symbol constituent, not a comment: z3's tactic output prints
+  ;; CBMC-style symbols verbatim (e.g. goto_symex::&92;guard#1), and a default
+  ;; `;` would comment out the rest of the line incl. the closing paren.
+  (make-readtable
+   (make-readtable (make-readtable #f #\x 'dispatch-macro read-hex)
+                   #\b
+                   'dispatch-macro
+                   read-bin)
+   #\;
+   #\a
+   #f))

--- a/parsing/transform.rkt
+++ b/parsing/transform.rkt
@@ -267,7 +267,13 @@
                                   (extend-env (car binding)
                                               (do (car (cdr binding)) env)
                                               env))
-                            (cons (cons binding new-bindings) env))))
+                            ;; keep the term binding, but with the env (already
+                            ;; inlined boolean bindings) substituted into its
+                            ;; value -- otherwise an inlined symbol (z3's a!1)
+                            ;; leaks out unbound inside e.g. an `ite` condition.
+                            (cons (cons (list (car binding) binded-expr)
+                                        new-bindings)
+                                  env))))
                     (cons '() env)
                     bindings))
            (define new-bindings (car new-tuple))

--- a/score.rkt
+++ b/score.rkt
@@ -22,9 +22,8 @@
 ; fp's equality
 (define (score/fp= c fp1 fp2)
   (cond
-    [(and (fp/nan? fp1) (fp/nan? fp2)) 1]
+    [(fp=-true? fp1 fp2) 1]
     [(or (fp/nan? fp1) (fp/nan? fp2)) 0]
-    [(bv= (FloatingPoint->BitVec fp1) (FloatingPoint->BitVec fp2)) 1]
     [else (fp-dist-score c fp1 fp2 #f)]))
 
 (define ((score/= c) v1 v2)
@@ -37,12 +36,7 @@
 (define score/bv≠ (λ (bv1 bv2) (if (bv= bv1 bv2) 0 1)))
 ; fp's inequality
 (define score/fp≠
-  (λ (fp1 fp2)
-    (cond
-      [(and (fp/nan? fp1) (fp/nan? fp2)) 0]
-      [(or (fp/nan? fp1) (fp/nan? fp2)) 1]
-      [else
-       (score/bv≠ (FloatingPoint->BitVec fp1) (FloatingPoint->BitVec fp2))])))
+  (λ (fp1 fp2) (if (fp=-true? fp1 fp2) 0 1)))
 
 (define (score/≠ v1 v2)
   (match v1
@@ -53,15 +47,12 @@
 ; fp's equality/inequality
 (define ((score/fpeq c) fp1 fp2)
   (cond
+    [(fp.eq-true? fp1 fp2) 1]
     [(or (fp/nan? fp1) (fp/nan? fp2)) 0]
-    [(and (fp/zero? fp1) (fp/zero? fp2)) 1]
-    [else (score/fp= c fp1 fp2)]))
+    [else (fp-dist-score c fp1 fp2 #f)]))
 
 (define (score/fp!eq fp1 fp2)
-  (cond
-    [(or (fp/nan? fp1) (fp/nan? fp2)) 1]
-    [(and (fp/zero? fp1) (fp/zero? fp2)) 0]
-    [else (score/bv≠ (FloatingPoint->BitVec fp1) (FloatingPoint->BitVec fp2))]))
+  (if (fp.eq-true? fp1 fp2) 0 1))
 
 (define bv-dist-score
   (λ (c bv1 bv2 eq)
@@ -111,62 +102,40 @@
 
 ; note that we're not pursuing a minimal set of operations here
 ; instead we give each operation its score as well as for its negation
-; fp's lt
+; fp's lt -- truth conditions live in fp.rkt (`*-true?`) and are shared with
+; eval's `ite`, so each is defined once. A satisfied atom still scores exactly 1;
+; the NaN and distance cases are unchanged.
 (define ((score/fplt c) fp1 fp2)
-  (cond
-    [(or (fp/nan? fp1) (fp/nan? fp2)) 0]
-    [(fp< fp1 fp2) 1]
-    ;; fp1 >= fp2 and fp1 != nan and fp2 != nan
-    [else (fp-dist-score c fp1 fp2 #t)]))
+  (cond [(fp.lt-true? fp1 fp2) 1]
+        [(or (fp/nan? fp1) (fp/nan? fp2)) 0]
+        [else (fp-dist-score c fp1 fp2 #t)]))
 
 (define ((score/fp!lt c) fp1 fp2)
-  (cond
-    [(or (fp/nan? fp1) (fp/nan? fp2)) 1]
-    [(fp≥ fp1 fp2) 1]
-    ;; fp1 < fp2 and fp1 != nan and fp2 != nan
-    [else (fp-dist-score c fp1 fp2 #f)]))
+  (if (fp.lt-true? fp1 fp2) (fp-dist-score c fp1 fp2 #f) 1))
 
 (define ((score/fpleq c) fp1 fp2)
-  (cond
-    [(or (fp/nan? fp1) (fp/nan? fp2)) 0]
-    [(fp≤ fp1 fp2) 1]
-    ;; fp1 > fp2 and fp1 != nan and fp2 != nan
-    [else (fp-dist-score c fp1 fp2 #f)]))
+  (cond [(fp.leq-true? fp1 fp2) 1]
+        [(or (fp/nan? fp1) (fp/nan? fp2)) 0]
+        [else (fp-dist-score c fp1 fp2 #f)]))
 
 (define ((score/fp!leq c) fp1 fp2)
-  (cond
-    [(or (fp/nan? fp1) (fp/nan? fp2)) 1]
-    [(fp> fp1 fp2) 1]
-    ;; fp1 <= fp2 and fp1 != nan and fp2 != nan
-    [else (fp-dist-score c fp1 fp2 #t)]))
+  (if (fp.leq-true? fp1 fp2) (fp-dist-score c fp1 fp2 #t) 1))
 
 (define ((score/fpgt c) fp1 fp2)
-  (cond
-    [(or (fp/nan? fp1) (fp/nan? fp2)) 0]
-    [(fp> fp1 fp2) 1]
-    ;; fp1 <= fp2 and fp1 != nan and fp2 != nan
-    [else (fp-dist-score c fp1 fp2 #t)]))
+  (cond [(fp.gt-true? fp1 fp2) 1]
+        [(or (fp/nan? fp1) (fp/nan? fp2)) 0]
+        [else (fp-dist-score c fp1 fp2 #t)]))
 
 (define ((score/fp!gt c) fp1 fp2)
-  (cond
-    [(or (fp/nan? fp1) (fp/nan? fp2)) 1]
-    [(fp≤ fp1 fp2) 1]
-    ;; fp1 > fp2 and fp1 != nan and fp2 != nan
-    [else (fp-dist-score c fp1 fp2 #f)]))
+  (if (fp.gt-true? fp1 fp2) (fp-dist-score c fp1 fp2 #f) 1))
 
 (define ((score/fpgeq c) fp1 fp2)
-  (cond
-    [(or (fp/nan? fp1) (fp/nan? fp2)) 0]
-    [(fp≥ fp1 fp2) 1]
-    ;; fp1 < fp2 and fp1 != nan and fp2 != nan
-    [else (fp-dist-score c fp1 fp2 #f)]))
+  (cond [(fp.geq-true? fp1 fp2) 1]
+        [(or (fp/nan? fp1) (fp/nan? fp2)) 0]
+        [else (fp-dist-score c fp1 fp2 #f)]))
 
 (define ((score/fp!geq c) fp1 fp2)
-  (cond
-    [(or (fp/nan? fp1) (fp/nan? fp2)) 1]
-    [(fp< fp1 fp2) 1]
-    ;; fp1 >= fp2 and fp1 != nan and fp2 != nan
-    [else (fp-dist-score c fp1 fp2 #t)]))
+  (if (fp.geq-true? fp1 fp2) (fp-dist-score c fp1 fp2 #t) 1))
 
 (define score2
   (λ (op1 op2 assignment env score-bf)

--- a/sls.rkt
+++ b/sls.rkt
@@ -220,3 +220,34 @@
                            (sls/do (+ i 1)
                                    (randomize/Assignment var-info))))))))])))
     (sls/do 0 initial-model)))
+
+;; RoundingMode variables are not searched; instead we enumerate the five
+;; rounding-mode constants in their place. For each of the 5^k combinations
+;; (RNE first, capped at 10000), substitute the chosen constants into `formula`
+;; and run `search` on the result; return the first sat (with the rm assignment
+;; appended to the model), otherwise unknown. `search` is a closure
+;; formula -> (cons 'sat models) | (cons 'unknown '()).
+(define (enumerate-rounding-modes rm-vars formula search)
+  (if (null? rm-vars)
+      (search formula)
+      (let* ([k (length rm-vars)]
+             [total (expt 5 k)]
+             [limit (min total 10000)])
+        (when (> total limit)
+          (eprintf "warning: ~a RoundingMode variables -> ~a combinations; trying ~a\n"
+                   k total limit))
+        (let loop ([idx 0])
+          (cond
+            [(>= idx limit) (cons 'unknown '())]
+            [else
+             ;; a rounding-mode constant per rm var, from the base-5 digits of idx
+             (define chosen
+               (for/list ([v (in-list rm-vars)] [i (in-naturals)])
+                 (list-ref ROUNDING-MODES (modulo (quotient idx (expt 5 i)) 5))))
+             (define subs (make-immutable-hash (map cons rm-vars chosen)))
+             (define result (search (substitute formula subs)))
+             (if (equal? (car result) 'sat)
+                 (cons 'sat
+                       (append (cdr result)
+                               (map (λ (v m) `(assert (= ,m ,v))) rm-vars chosen)))
+                 (loop (add1 idx)))])))))

--- a/sls.rkt
+++ b/sls.rkt
@@ -83,9 +83,16 @@
                 (apply append
                        (map (λ (candVar)
                               (define val (get-value assignment candVar))
-                              (map ((curry update/Assignment) assignment
-                                                              candVar)
-                                   (get/fp-neighbors val ni)))
+                              ;; dispatch by type: fp vars use the ni-th VNS
+                              ;; neighborhood, bit-vector/Bool vars use their
+                              ;; (ni-independent) extended neighborhood.
+                              (define nbrs
+                                (match val
+                                  [(struct FloatingPoint _) (get/fp-neighbors val ni)]
+                                  [(struct BitVec _) (get/bv-extended-neighbors val)]
+                                  [_ '()]))
+                              (map ((curry update/Assignment) assignment candVar)
+                                   nbrs))
                             candVars)))]
              [select/Move (λ (candVars)
                             ;(log-debug "candvars~a\n" candVars)


### PR DESCRIPTION
OL1V3R could not run the SMT-COMP 2025 QF_FP benchmarks — it crashed during
  parsing, evaluation, or on RoundingMode variables. This branch fixes that. On the
  151-instance SAT+UNKNOWN set, OL1V3R run *properly* (jfs-opt simplify + solve-eqs)
  now solves ~137/151; soundness checked (0 `sat` on 124 unsat instances; sat models
  cvc5-validated).

  ### Parsing (read z3's preprocessed output)
  - **read-hex**: `#F` was the boolean false, not the char `#\F`, so any uppercase
    hex digit crashed `char<=?`; z3's output uses uppercase hex, breaking jfs-opt
    entirely. Fixed + EOF guards on `read-hex`/`read-bin`. (`eac41cf`)
  - **`;` in symbols**: z3 prints CBMC symbols verbatim (`goto_symex::&92;guard#1`);
    a comment-`;` swallowed the closing paren. Make `;` a symbol constituent. (`5f3a4ef`)

  ### Evaluator
  - **ite**: term-level if-then-else was unsupported. (`eac41cf`)
  - **let substitution**: `remove-let-bindings` kept non-boolean bindings without
    substituting already-inlined symbols, leaking z3 solve-eqs's `a!1` unbound. (`c4c56e3`)
  - **fp=-true? NaN guard**: avoid `FloatingPoint->BitVec` on a NaN. (`5f3a4ef`)
  - **sls-vns**: dispatch neighbor generation by value type (fp vs bit-vector/Bool),
    like the basic `sls` does. (`e4bcbea`)

  ### RoundingMode support (`5f3a4ef`)
  The original ignored the rounding mode. Now `fp.{add,sub,mul,div,sqrt}` honor it
  via `bf-rounding-mode`, and RoundingMode *variables* are enumerated over the
  rounding-mode constants (mirrors the Rust fp-sls `solve`). `roundNearestTiesToAway`
  is unsupported (bigfloat has no ties-to-away) — refused, not approximated, with a
  note (incomplete on RNA; none in the eval set).

  ### Refactor (`0377fce`)
  Lift the atom truth conditions into `fp.rkt`, shared by `score` and `eval`'s `ite` —
  no duplication, no runtime mutation, behavior preserved.