### PR TITLE
ci: add GitHub Actions (compile + unit + smoke); fix fp-test; update …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Z3 is needed at runtime for the default `simplify` pass and for
+      # --elim-eqs / --try-real-models (OL1V3R shells out to `z3`).
+      - name: Install Z3
+        run: sudo apt-get update && sudo apt-get install -y z3
+
+      - name: Set up Racket
+        uses: Bogdanp/setup-racket@v1.11
+        with:
+          architecture: x64
+          distribution: full
+          variant: CS
+          version: stable
+
+      - name: Compile
+        run: raco make main.rkt
+
+      - name: Unit tests
+        run: racket test/data/fp-test.rkt
+
+      - name: Smoke tests (end-to-end solve)
+        run: |
+          set -euo pipefail
+          for f in test/smoke/sat-rm.smt2 test/smoke/sat-ite.smt2; do
+            echo "== $f =="
+            out=$(racket main.rkt --vns --elim-eqs --try-real-models --step 1000000 "$f")
+            echo "$out"
+            grep -qx sat <<<"$out"
+          done

--- a/README.md
+++ b/README.md
@@ -1,10 +1,74 @@
-# Overview
-This project is intended as a reimplementation of "Stochastic Local Search for Satisfiability Modulo Theories" in Racket. But now it serves as an incomplete QF_(BV)FP solver.
+# OL1V3R
 
-# Dependency
-Just Racket (what else should you need?)
+[![CI](https://github.com/soarlab/OL1V3R/actions/workflows/ci.yml/badge.svg)](https://github.com/soarlab/OL1V3R/actions/workflows/ci.yml)
 
-Maybe Z3, too. Z3 needs to be installed if the options `--try-real-models` and `--elim-eqs` are enabled. 
+A theory-level **stochastic local search (SLS)** solver for the SMT theory of
+floating-point arithmetic (`QF_FP`, plus some `QF_BV`), a reimplementation of the
+ideas in *"Stochastic Local Search for Satisfiability Modulo Theories"*. It
+searches the space of variable assignments directly, guided by a structure-aware
+objective, rather than bit-blasting to SAT.
 
-# How To
-See `racket main.rkt -h`
+It is **incomplete and satisfiability-only**: it answers `sat` (with a model) when
+it finds a satisfying assignment, and `unknown` otherwise. It never reports
+`unsat` — on an unsatisfiable formula it simply searches until its step budget or
+the time limit runs out.
+
+Capabilities:
+
+- IEEE-754 floating point of arbitrary `(exp, sig)` widths, computed bit-faithfully.
+- Honors the SMT rounding-mode constants, and **enumerates `RoundingMode`
+  variables** over them. (`roundNearestTiesToAway` is not supported — Racket's
+  bigfloat has no ties-to-away mode — so instances requiring it are not solved.)
+- Term-level `if-then-else`.
+
+## Dependencies
+
+- **[Racket](https://racket-lang.org/)** (8.x or newer).
+- **[Z3](https://github.com/Z3Prover/z3)** on `PATH` — used for the default
+  `simplify` preprocessing and for `--elim-eqs` / `--try-real-models`. Pass
+  `--no-simplify` (and omit those flags) to run without Z3.
+
+## Build
+
+```sh
+raco make main.rkt        # compile to bytecode (recommended before benchmarking)
+```
+
+## Usage
+
+```sh
+racket main.rkt [options] <file.smt2>
+```
+
+A good configuration for hard instances:
+
+```sh
+racket main.rkt --vns --elim-eqs --try-real-models --step 100000000 --print-models file.smt2
+```
+
+Key options (`racket main.rkt -h` for the full list):
+
+| option | meaning |
+| --- | --- |
+| `--vns` | variable-neighborhood search |
+| `--elim-eqs` | additional Z3 `solve-eqs` preprocessing |
+| `--try-real-models` | seed the search from a Z3 real-relaxation model |
+| `--step <n>` | number of search steps (default is small — set it large) |
+| `--seed <n>` | RNG seed (the search is deterministic for a fixed seed) |
+| `--no-simplify` | skip the default Z3 `simplify` preprocessing |
+| `--print-models` | print the model on `sat` |
+
+> Note: `--step` defaults to a small value; hard instances need a large budget
+> (e.g. `100000000`).
+
+## Tests
+
+```sh
+racket test/data/fp-test.rkt          # rackunit unit tests
+# end-to-end smoke tests:
+racket main.rkt --vns --elim-eqs --try-real-models --step 1000000 test/smoke/sat-rm.smt2
+racket main.rkt --vns --elim-eqs --try-real-models --step 1000000 test/smoke/sat-ite.smt2
+```
+
+CI (GitHub Actions, `.github/workflows/ci.yml`) compiles the project, runs the
+unit tests, and runs the smoke tests on every push and pull request.

--- a/test/data/fp-test.rkt
+++ b/test/data/fp-test.rkt
@@ -2,7 +2,8 @@
 
 (require rackunit
          rackunit/text-ui
-         "../../data/fp.rkt")
+         "../../data/fp.rkt"
+         "../../data/bit-vec.rkt")
 
 (define fp-tests
   (test-suite
@@ -11,13 +12,21 @@
                (check-pred fp/infinity? (real->FloatingPoint 65520.0 5 11))
                (check-pred fp/positive? (real->FloatingPoint 0.0 5 11))
                (check-pred fp/negative? (real->FloatingPoint -0.0 5 11)))
-   (test-suite "Floating-point to bit-vector conversions")
    (test-suite "Floating-point arithmetic"
                (check-pred (λ (x) (and (fp/positive? x) (fp/infinity? x)))
-                           (eval/fpdiv (real->FloatingPoint 1.0 5 11)
+                           (eval/fpdiv 'nearest (real->FloatingPoint 1.0 5 11)
                                        (real->FloatingPoint 0.0 5 11)))
                (check-pred (λ (x) (and (fp/negative? x) (fp/infinity? x)))
-                           (eval/fpdiv (real->FloatingPoint 1.0 5 11)
-                                       (real->FloatingPoint -0.0 5 11))))))
+                           (eval/fpdiv 'nearest (real->FloatingPoint 1.0 5 11)
+                                       (real->FloatingPoint -0.0 5 11))))
+   (test-suite "Rounding modes are honored"
+               ;; 1/3 is inexact, so rounding toward +inf and -inf must differ
+               ;; (this would collapse if the rounding mode were ignored).
+               (let ([one   (real->FloatingPoint 1.0 5 11)]
+                     [three (real->FloatingPoint 3.0 5 11)])
+                 (check-false
+                  (bv= (FloatingPoint->BitVec (eval/fpdiv 'up   one three))
+                       (FloatingPoint->BitVec (eval/fpdiv 'down one three))))))))
 
-(run-tests fp-tests)
+;; exit non-zero on any failure/error so CI fails loudly
+(exit (run-tests fp-tests))

--- a/test/smoke/sat-ite.smt2
+++ b/test/smoke/sat-ite.smt2
@@ -1,0 +1,7 @@
+; smoke test: satisfiable, exercises a term-level if-then-else
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 8 24))
+(declare-const b Bool)
+(assert (not (fp.isNaN x)))
+(assert (fp.eq (ite b x (fp.neg x)) x))
+(check-sat)

--- a/test/smoke/sat-rm.smt2
+++ b/test/smoke/sat-rm.smt2
@@ -1,0 +1,6 @@
+; smoke test: satisfiable, exercises fp arithmetic with a non-default rounding mode
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 8 24))
+(assert (fp.isNormal x))
+(assert (fp.gt (fp.mul roundTowardPositive x x) (_ +zero 8 24)))
+(check-sat)


### PR DESCRIPTION
…README

- .github/workflows/ci.yml: Bogdanp/setup-racket + Z3, raco make, rackunit, and end-to-end smoke tests (sat instances exercising rounding modes and ite).
- test/data/fp-test.rkt: the rm change made eval/fpdiv take a mode arg; pass it, add a rounding-mode regression (up != down on an inexact result), and exit non-zero on failure so CI catches regressions.
- test/smoke/{sat-rm,sat-ite}.smt2: tiny end-to-end smoke instances.
- README: build/usage/options/tests, soundness (sat-only), Z3 dependency, badge.